### PR TITLE
add @import 'ladda'; to make it work in Rails

### DIFF
--- a/vendor/assets/stylesheets/ladda-theme.scss
+++ b/vendor/assets/stylesheets/ladda-theme.scss
@@ -1,5 +1,6 @@
 /** Contains the default Ladda button theme styles */
 
+@import 'ladda';
 
 /*************************************
  * CONFIG


### PR DESCRIPTION
I have rails 4.1.4

Without @import 'ladda'; in ladda-theme.scss I see this error

(Undefined mixin 'buttonColor'.
  (in /Users/user/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bundler/gems/ladda-rails-5c51ac8bc99f/vendor/assets/stylesheets/ladda-theme.scss:41)):
